### PR TITLE
Escape slash in project and branch name

### DIFF
--- a/waitForJenkins.sh
+++ b/waitForJenkins.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-JOB_URL = $JENKINS_HOST/job/$(echo $CI_PROJECT_NAME | sed 's/\//%252F/g')/job/$(echo $CI_COMMIT_REF_NAME | sed 's/\//%252F/g')
+JOB_URL=$JENKINS_HOST/job/$(echo $CI_PROJECT_NAME | sed 's/\//%252F/g')/job/$(echo $CI_COMMIT_REF_NAME | sed 's/\//%252F/g')
 
 echo Waiting for Jenkin\'s job $JOB_URL
 

--- a/waitForJenkins.sh
+++ b/waitForJenkins.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 
-echo Waiting for Jenkin\'s job $JENKINS_HOST/job/$CI_PROJECT_NAME/job/$CI_COMMIT_REF_NAME
+JOB_URL = $JENKINS_HOST/job/$(echo $CI_PROJECT_NAME | sed 's/\//%252F/g')/job/$(echo $CI_COMMIT_REF_NAME | sed 's/\//%252F/g')
 
-while [ $(curl --insecure -sS $(curl --insecure -sS $JENKINS_HOST/job/$CI_PROJECT_NAME/job/$CI_COMMIT_REF_NAME/api/json | jq -r .builds[0].url)api/json | jq .building) == "true" ]
+echo Waiting for Jenkin\'s job $JOB_URL
+
+while [ $(curl --insecure -sS $(curl --insecure -sS $JOB_URL/api/json | jq -r .builds[0].url)api/json | jq .building) == "true" ]
 do
 	sleep 3
 done
 
-if [ $(curl --insecure -sS $(curl --insecure -sS $JENKINS_HOST/job/$CI_PROJECT_NAME/job/$CI_COMMIT_REF_NAME/api/json | jq -r .builds[0].url)api/json | jq -r .result) == "SUCCESS" ]
+if [ $(curl --insecure -sS $(curl --insecure -sS $JOB_URL/api/json | jq -r .builds[0].url)api/json | jq -r .result) == "SUCCESS" ]
 then
 	exit 0
 fi


### PR DESCRIPTION
Slashes in project and branch names have failed the jobs.